### PR TITLE
Update WASimCommander

### DIFF
--- a/Controlzmo/Controlzmo.csproj
+++ b/Controlzmo/Controlzmo.csproj
@@ -51,13 +51,13 @@
 
   <ItemGroup>
     <Reference Include="WASimCommander.WASimClient, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(ProjectDir)\..\..\WASimCommander_SDK-v1.0.0.7-beta3\lib\MSVS-2019\managed\WASimCommander.WASimClient.dll</HintPath>
+      <HintPath>$(ProjectDir)\..\..\WASimCommander_SDK-v1.3.1.0\lib\managed\net8\WASimCommander.WASimClient.dll</HintPath>
       <Private>true</Private>
       <EmbedInteropTypes>false</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ContentWithTargetPath Include="$(ProjectDir)\..\..\WASimCommander_SDK-v1.0.0.7-beta3\lib\MSVS-2019\managed\\Ijwhost.dll">
+    <ContentWithTargetPath Include="$(ProjectDir)\..\..\WASimCommander_SDK-v1.3.1.0\lib\managed\net8\Ijwhost.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>Ijwhost.dll</TargetPath>
     </ContentWithTargetPath>


### PR DESCRIPTION
We don't appear to be using it any more. Should we switch to it? Could we use the Mobiflight one instead?